### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-ships.yml
+++ b/.github/workflows/update-ships.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hackclub/swirl/security/code-scanning/1](https://github.com/hackclub/swirl/security/code-scanning/1)

Add an explicit `permissions` block to this workflow so the `GITHUB_TOKEN` is constrained to only what the job needs.

Best fix here (without changing behavior): set workflow-level permissions to:
- `contents: write` (required because the workflow commits and pushes changes)

Since there is only one job and it needs to push, workflow-level permission is simple and sufficient. Edit `.github/workflows/update-ships.yml` by inserting the `permissions` block after the `on:` section (before `jobs:`), keeping all existing steps unchanged.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
