### PR TITLE
Add individual Hackatime requirement

### DIFF
--- a/pages/requirements.html
+++ b/pages/requirements.html
@@ -102,6 +102,10 @@ html_attrs: 'style="scroll-behavior: smooth"'
       since.
     </li>
     <li>Frameworks and other languages are not permitted.</li>
+    <li>
+      For individual submissions, you must track your time using
+      <a href="https://hackatime.hackclub.com/">Hackatime</a>.
+    </li>
   </div>
 </div>
 <br /><br />


### PR DESCRIPTION
Per [the form](https://forms.hackclub.com/swirl),

> [a Hackatime key is] mandatory for individual submissions.

However, this is not on the requirements page; only on the submission page, so people (including me) make their website and are only informed when they are ready submitting.

This PR adds the Hackatime requirement to requirements.html.